### PR TITLE
Fix submodule URL to a git URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "payutc-json-client"]
 	path = payutc-json-client
-	url = git@github.com:payutc/payutc-json-client.git
+	url = git://github.com/payutc/scoobydoo.git


### PR DESCRIPTION
Faut toujours mettre des URL en git pour les submodules, parce que https ne marche pas sans config depuis le réseau UTC et ssh oblige à avoir une clé sur la machine.
