### PR TITLE
Fix submodule URL (again)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "payutc-json-client"]
 	path = payutc-json-client
-	url = git://github.com/payutc/scoobydoo.git
+	url = git://github.com/payutc/payutc-json-client.git


### PR DESCRIPTION
`git://` c'est bien, mais autant prendre le bon repo...
