### PR TITLE
desactivation du module plage horaire

### DIFF
--- a/modules/plagehoraire/ModulePlagehoraire.class.php
+++ b/modules/plagehoraire/ModulePlagehoraire.class.php
@@ -103,11 +103,11 @@ class ModulePlagehoraire extends Module {
 	}
 
 	public function has_rights() {
-		global $AADMIN;
+		/*global $AADMIN;
 		$right=$AADMIN->get_fundations_with_right("ADMIN");
 		if(count($right["success"]) > 0)
 			return True;
-		else
+		else*/
 			return False;
 	}
 }


### PR DESCRIPTION
Ce module ne sert à rien pour l'instant et je ne sais meme pas si on va le garder...

Tout ce qui est sur, c'est qu'il fait très moche dans scoobydoo et est inexplicable lors de démonstration... Du coup je l'ai désactivé pour qu'il n'apparaissent plus dans le menu...

Il sera surement à supprimer dans le futur... Mais j'attend le mois de juillet qu'on étudie la question.
